### PR TITLE
feat: 디스코드 웹훅 모듈화

### DIFF
--- a/src/types/utils/webhook.ts
+++ b/src/types/utils/webhook.ts
@@ -1,0 +1,15 @@
+export interface Embed {
+    title: string;
+    description: string;
+    color: number;
+}
+
+export interface WebhookAuthor {
+    name: string;
+    avatar_url: string;
+}
+
+export interface WebhookConfig extends Partial<WebhookAuthor> {
+    content: string;
+    embeds?: Embed[];
+}

--- a/src/utils/webhook.ts
+++ b/src/utils/webhook.ts
@@ -1,0 +1,24 @@
+import { env } from "../constants/env";
+import { WebhookConfig } from "../types/utils/webhook";
+
+const WEBHOOK_AUTHOR_NAME = '선린투데이';
+const WEBHOOK_AUTHOR_AVATAR_URL = 'https://avatars.githubusercontent.com/u/72495729';
+
+export function sendWebhook({
+    content, embeds, name = WEBHOOK_AUTHOR_NAME, avatar_url = WEBHOOK_AUTHOR_AVATAR_URL
+}: WebhookConfig) {
+    fetch(env.DISCORD_WEBHOOK_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            // Webhook author
+            username: name,
+            avatar_url: avatar_url,
+
+            content: content,
+            embeds: embeds,
+        })
+    });
+}


### PR DESCRIPTION
자주 사용할 디스코드 웹훅을 모듈화 하였습니다

discord.js document에서 Webhook author을 전달할 땐 name, avatar 속성을 사용하라고 명시되어있지만 username, avatar_url을 사용해야 한다 :<

https://discord.com/developers/docs/resources/webhook